### PR TITLE
Add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ stringsifter = "~=2.0"
 colorama = "^0.4.4"
 fileupload = "^0.1.5"
 pyminizip = "^0.2.4"
+pandas = "^1.3.4"
+plotly = "^5.4.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Updated `pyproject.toml` to include Pandas and Plotly.
Noticed notebooks `Processes.ipynb` and `Sysmon-Stats.ipynb` importing `pandas` and `plotly` while those libraries where not referenced in `requirements.txt` or `pyproject.toml`, and this caused an import exception.

After updating `pyproject.toml` I ran `poetry update` and this solved the issue.

Now, a single import remain unfixed and that is the `malware` import which exists in `Processes.ipynb`. Sadly, I could not fix it as I am unsure what that libraries is and I could not find it on PyPi. I was only able to find https://pypi.org/project/malware/ and that library looks suspicious.

Love this project, thanks for your efforts!